### PR TITLE
feat: add release-please automation for semantic versioning

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,20 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          release-type: go


### PR DESCRIPTION
Automates release management using Google's release-please action:
- Analyzes conventional commits (feat, fix, etc.)
- Auto-generates CHANGELOG.md
- Creates release PR with version bumps
- Creates GitHub release and tags when PR is merged

This eliminates manual tag creation while maintaining semantic versioning based on commit messages.