### PR TITLE
fix: update goreleaser config to version 2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 # This is a library package, not an executable, so we skip building binaries
 builds:
   - skip: true


### PR DESCRIPTION
GoReleaser requires version: 2 format for configuration files.
Added version: 2 at the top of .goreleaser.yml to fix release job.